### PR TITLE
Add example_nodes.json and update README

### DIFF
--- a/example_nodes.json
+++ b/example_nodes.json
@@ -1,0 +1,36 @@
+{
+  "inputStreamExample": {
+    "path": "input.mp4",
+    "name": "raw_video",
+    "stream_type": "Input",
+    "inputs": null
+  },
+  "filterNodeExample": {
+    "name": "scaler",
+    "inputs": [
+      "raw_video:v"
+    ],
+    "outputs": [
+      "scaled_video"
+    ],
+    "filters": [
+      {
+        "name": "scale",
+        "options": {
+          "HashMap": {
+            "width": "1280",
+            "height": "720"
+          }
+        }
+      }
+    ]
+  },
+  "outputStreamExample": {
+    "path": "output_scaled.mp4",
+    "name": "final_output",
+    "stream_type": "Output",
+    "inputs": [
+      "scaled_video"
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces an `example_nodes.json` file. This file provides example JSON representations for:
- An input Stream object
- A FilterNode object (including a nested Filter with HashMap options)
- An output Stream object

These examples are intended to demonstrate how the library's Rust structs (`Stream`, `FilterNode`, `Filter`, `FilterOptions`) are serialized to JSON, aligning with the structures used in testing.

The "JSON Representation Examples" section previously in README.md has been removed as this information now resides in the dedicated `example_nodes.json` file.